### PR TITLE
Remove colons from NSQ filenames

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
   val resolvers = Seq(
     Resolver.jcenterRepo,
     "Snowplow Analytics Maven releases repo" at "http://maven.snplow.com/releases/",
-    "Twitter maven repo"                     at "http://maven.twttr.com/"
+    "Twitter maven repo"                     at "https://maven.twttr.com/"
   )
 
   object V {

--- a/src/main/scala/com.snowplowanalytics.s3/loader/NsqSourceExecutor.scala
+++ b/src/main/scala/com.snowplowanalytics.s3/loader/NsqSourceExecutor.scala
@@ -77,7 +77,7 @@ class NsqSourceExecutor(
   val msgBuffer = new ListBuffer[EmitterInput]()
 
   val s3Emitter = new S3Emitter(config.s3, provider, badSink, maxConnectionTime, tracker)
-  private val TimeFormat = DateTimeFormat.forPattern("HH:mm:ss.SSS").withZone(DateTimeZone.UTC)
+  private val TimeFormat = DateTimeFormat.forPattern("HHmmssSSS").withZone(DateTimeZone.UTC)
   private val DateFormat = DateTimeFormat.forPattern("yyyy-MM-dd").withZone(DateTimeZone.UTC)
 
   private def getBaseFilename(startTime: Long, endTime: Long): String = {


### PR DESCRIPTION
Change time format for files being stored to S3 coming from NSQ to remove colons and prevent processing failures in downstream ETL process as described in #125.

Resulting key names will be like `2018-02-14-035255281-035421489-1579626703.lzo` instead of `2018-02-14-03:52:55.281-03:54:21.489-1579626703.lzo`