### PR TITLE
Issue-134: allow configurable and dynamic s3 path

### DIFF
--- a/examples/config.hocon.sample
+++ b/examples/config.hocon.sample
@@ -88,6 +88,7 @@ s3 {
   bucket = "{{s3bucket}}"
   # optional directory structure to use while storing data on s3, you can place date format strings which will be
   # replaced with date time values
+  # eg: directoryPattern = "enriched/good/run_yr={YYYY}/run_mo={MM}/run_dy={DD}"
   directoryPattern = "{{s3DirectoryPattern}}"
 
   # Format is one of lzo or gzip

--- a/examples/config.hocon.sample
+++ b/examples/config.hocon.sample
@@ -82,6 +82,9 @@ streams {
 s3 {
   region = "{{s3Region}}"
   bucket = "{{s3bucket}}"
+  # optional directory structure to use while storing data on s3, you can place date format strings which will be
+  # replaced with date time values
+  directoryPattern = "{{s3DirectoryPattern}}"
 
   # Format is one of lzo or gzip
   # Note, that you can use gzip only for enriched data stream.

--- a/src/main/scala/com.snowplowanalytics.s3/loader/DynamicPath.scala
+++ b/src/main/scala/com.snowplowanalytics.s3/loader/DynamicPath.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package com.snowplowanalytics.s3.loader
+
+import org.joda.time.{DateTime, DateTimeZone}
+import org.joda.time.format.DateTimeFormat
+
+import scala.util.Try
+
+/**
+  * Object to handle S3 dynamic path generation
+  */
+object DynamicPath {
+  def decorateDirectoryWithTime(directoryPattern: String, fileName: String, decoratorDateTime: DateTime): String = {
+    // replace the pattern with actual date values
+    val detectBracesExpression = "\\{(.*?)\\}".r
+    val replacements = detectBracesExpression
+      .findAllMatchIn(directoryPattern)
+      .map(_.toString.trim)
+      .map(str => {
+        val converted = Try(DateTimeFormat.forPattern(str).withZone(DateTimeZone.UTC).print(decoratorDateTime))
+        (str, converted.getOrElse(str))
+      }
+      )
+      .toList
+    val directory = replacements.foldLeft(directoryPattern) {
+      (dir, replacement) => dir.replace(replacement._1, replacement._2)
+    }
+    // ensure trailing slash in the directory only if a pattern was supplied
+    val finalPath = if (directory.endsWith("/") || directory.isEmpty) s"$directory$fileName"
+    else s"$directory/$fileName"
+    finalPath
+  }
+}
+

--- a/src/main/scala/com.snowplowanalytics.s3/loader/S3Emitter.scala
+++ b/src/main/scala/com.snowplowanalytics.s3/loader/S3Emitter.scala
@@ -21,8 +21,6 @@ package com.snowplowanalytics.s3.loader
 //Java
 import java.io.ByteArrayInputStream
 
-import scala.util.Try
-
 // Scala
 import scala.util.control.NonFatal
 import scala.collection.JavaConversions._
@@ -165,7 +163,7 @@ class S3Emitter(
       try {
         val outputStream = namedStream.stream
 
-        val s3Key = DynamicPath.decorateDirectoryWithTime(directoryPattern.getOrElse(""), namedStream.filename, connectionAttemptStartDateTime)
+        val s3Key = DynamicPath.decorateDirectoryWithTime(directoryPattern, namedStream.filename, connectionAttemptStartDateTime)
 
         val inputStream = new ByteArrayInputStream(outputStream.toByteArray)
 

--- a/src/main/scala/com.snowplowanalytics.s3/loader/S3Emitter.scala
+++ b/src/main/scala/com.snowplowanalytics.s3/loader/S3Emitter.scala
@@ -21,6 +21,8 @@ package com.snowplowanalytics.s3.loader
 //Java
 import java.io.ByteArrayInputStream
 
+import scala.util.Try
+
 // Scala
 import scala.util.control.NonFatal
 import scala.collection.JavaConversions._
@@ -165,10 +167,12 @@ class S3Emitter(
         // replace the pattern with actual date values
         val detectBracesExpression = "\\{(.*?)\\}".r
         val replacements = detectBracesExpression
-          .findAllMatchIn(bucket)
+          .findAllMatchIn(directoryPattern.getOrElse(""))
           .map(_.toString.trim)
-          .map(str =>
-            (str, DateTimeFormat.forPattern(str).withZone(DateTimeZone.UTC).print(connectionAttemptStartDateTime))
+          .map(str => {
+            val converted = Try(DateTimeFormat.forPattern(str).withZone(DateTimeZone.UTC).print(connectionAttemptStartDateTime))
+            (str, converted.getOrElse(str))
+          }
           )
           .toList
         var directory = directoryPattern.getOrElse("")

--- a/src/main/scala/com.snowplowanalytics.s3/loader/S3Emitter.scala
+++ b/src/main/scala/com.snowplowanalytics.s3/loader/S3Emitter.scala
@@ -179,8 +179,8 @@ class S3Emitter(
         for (replacement <- replacements) {
           directory = directory.replace(replacement._1, replacement._2)
         }
-        // ensure trailing slash in the directory
-        directory = if (directory.endsWith("/")) directory else s"$directory/"
+        // ensure trailing slash in the directory if it exists
+        directory = if (directory.endsWith("/") && ! directory.isEmpty) directory else s"$directory/"
         val filename = s"$directory${namedStream.filename}"
         val inputStream = new ByteArrayInputStream(outputStream.toByteArray)
 

--- a/src/main/scala/com.snowplowanalytics.s3/loader/S3Emitter.scala
+++ b/src/main/scala/com.snowplowanalytics.s3/loader/S3Emitter.scala
@@ -175,13 +175,13 @@ class S3Emitter(
           }
           )
           .toList
-        var directory = directoryPattern.getOrElse("")
-        for (replacement <- replacements) {
-          directory = directory.replace(replacement._1, replacement._2)
+        val directory = replacements.foldLeft(directoryPattern.getOrElse("")) {
+          (dir, replacement) => dir.replace(replacement._1, replacement._2)
         }
-        // ensure trailing slash in the directory if it exists
-        directory = if (directory.endsWith("/") && ! directory.isEmpty) directory else s"$directory/"
-        val filename = s"$directory${namedStream.filename}"
+        // ensure trailing slash in the directory only if a pattern was supplied
+        val filename = if (directory.endsWith("/") || directory.isEmpty) s"$directory${namedStream.filename}"
+        else s"$directory/${namedStream.filename}"
+
         val inputStream = new ByteArrayInputStream(outputStream.toByteArray)
 
         val objMeta = new ObjectMetadata()

--- a/src/main/scala/com.snowplowanalytics.s3/loader/model.scala
+++ b/src/main/scala/com.snowplowanalytics.s3/loader/model.scala
@@ -64,7 +64,8 @@ package model {
     region: String,
     bucket: String,
     format: String,
-    maxTimeout: Long
+    maxTimeout: Long,
+    directoryPattern: Option[String]
   ) {
     val endpoint = region match {
       case "us-east-1" => "https://s3.amazonaws.com"

--- a/src/test/scala/com/snowplowanalytics/s3/loader/DynamicPathSpec.scala
+++ b/src/test/scala/com/snowplowanalytics/s3/loader/DynamicPathSpec.scala
@@ -1,0 +1,38 @@
+package com.snowplowanalytics.s3.loader
+
+import org.joda.time.DateTime
+import org.specs2.mutable.Specification
+
+
+class DynamicPathSpec extends Specification {
+
+  "DynamicPathSpec" should {
+    val file = "bar.gz"
+    val time = new DateTime(100000)
+
+    "correctly decorate Time formats with one time pattern" in {
+      val directoryPattern = "something/{YYYY}"
+      val actual = DynamicPath.decorateDirectoryWithTime(directoryPattern, file, time)
+      actual must_== "something/{1970}/bar.gz"
+    }
+
+    "correctly decorate Time formats with multiple time patterns" in {
+      val directoryPattern = "something/{YYYY}/{mm}dy={dd}"
+      val actual = DynamicPath.decorateDirectoryWithTime(directoryPattern, file, time)
+      actual must_== "something/{1970}/{01}dy={01}/bar.gz"
+    }
+
+    "correctly decorate Time formats with extra trailing slash" in {
+      val directoryPattern = "something/{YYYY}/{mm}dy={dd}/"
+      val actual = DynamicPath.decorateDirectoryWithTime(directoryPattern, file, time)
+      actual must_== "something/{1970}/{01}dy={01}/bar.gz"
+    }
+
+    "correctly decorate Time formats with invalid time format" in {
+      val directoryPattern = "something/{YYYY}/{mm}dy={dd}/{foo}"
+      val actual = DynamicPath.decorateDirectoryWithTime(directoryPattern, file, time)
+      actual must_== "something/{1970}/{01}dy={01}/{foo}/bar.gz"
+    }
+
+  }
+}

--- a/src/test/scala/com/snowplowanalytics/s3/loader/DynamicPathSpec.scala
+++ b/src/test/scala/com/snowplowanalytics/s3/loader/DynamicPathSpec.scala
@@ -1,3 +1,15 @@
+/*
+ * Copyright (c) 2015 Snowplow Analytics Ltd. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
 package com.snowplowanalytics.s3.loader
 
 import org.joda.time.DateTime
@@ -11,27 +23,33 @@ class DynamicPathSpec extends Specification {
     val time = new DateTime(100000)
 
     "correctly decorate Time formats with one time pattern" in {
-      val directoryPattern = "something/{YYYY}"
+      val directoryPattern = Some("something/{YYYY}")
       val actual = DynamicPath.decorateDirectoryWithTime(directoryPattern, file, time)
       actual must_== "something/{1970}/bar.gz"
     }
 
     "correctly decorate Time formats with multiple time patterns" in {
-      val directoryPattern = "something/{YYYY}/{mm}dy={dd}"
+      val directoryPattern = Some("something/{YYYY}/{mm}dy={dd}")
       val actual = DynamicPath.decorateDirectoryWithTime(directoryPattern, file, time)
       actual must_== "something/{1970}/{01}dy={01}/bar.gz"
     }
 
     "correctly decorate Time formats with extra trailing slash" in {
-      val directoryPattern = "something/{YYYY}/{mm}dy={dd}/"
+      val directoryPattern = Some("something/{YYYY}/{mm}dy={dd}/")
       val actual = DynamicPath.decorateDirectoryWithTime(directoryPattern, file, time)
       actual must_== "something/{1970}/{01}dy={01}/bar.gz"
     }
 
     "correctly decorate Time formats with invalid time format" in {
-      val directoryPattern = "something/{YYYY}/{mm}dy={dd}/{foo}"
+      val directoryPattern = Some("something/{YYYY}/{mm}dy={dd}/{foo}")
       val actual = DynamicPath.decorateDirectoryWithTime(directoryPattern, file, time)
       actual must_== "something/{1970}/{01}dy={01}/{foo}/bar.gz"
+    }
+
+    "correctly handle no format" in {
+      val directoryPattern = None
+      val actual = DynamicPath.decorateDirectoryWithTime(directoryPattern, file, time)
+      actual must_== "bar.gz"
     }
 
   }


### PR DESCRIPTION
This PR solves for https://github.com/snowplow/snowplow-s3-loader/issues/134 by enabling the use of `DateTimeFormat` patterns enclosed in {curly braces} as an optional s3 configuration - `directoryPattern`.

The configuration can be used to supply a static directory or use the emitter's connection start time to fill in dynamic values replacing time formatted chunks in braces. All values which do not conform the `DateTimeFormat` are left as is.