### PR TITLE
Remove curly braces from transformed directory pattern

### DIFF
--- a/src/main/scala/com.snowplowanalytics.s3/loader/DynamicPath.scala
+++ b/src/main/scala/com.snowplowanalytics.s3/loader/DynamicPath.scala
@@ -43,9 +43,12 @@ object DynamicPath {
             (str, Try(DateTimeFormat.forPattern(str).withZone(DateTimeZone.UTC).print(decoratorDateTime)).getOrElse(str))
           }
           .toList
-        val directory = replacements.foldLeft(pattern) {
+        val directoryWithBraces = replacements.foldLeft(pattern) {
           (dir, replacement) => dir.replace(replacement._1, replacement._2)
         }
+        // Remove braces from the final pure directory path
+        val pure = """\{([^}]*)\}""".r
+        val directory = pure.replaceAllIn(directoryWithBraces, "$1")
         // ensure trailing slash in the directory only if a pattern was supplied
         val finalPath = if (directory.endsWith("/") || directory.isEmpty) s"$directory$fileName"
         else s"$directory/$fileName"

--- a/src/test/scala/com/snowplowanalytics/s3/loader/DynamicPathSpec.scala
+++ b/src/test/scala/com/snowplowanalytics/s3/loader/DynamicPathSpec.scala
@@ -25,25 +25,25 @@ class DynamicPathSpec extends Specification {
     "correctly decorate Time formats with one time pattern" in {
       val directoryPattern = Some("something/{YYYY}")
       val actual = DynamicPath.decorateDirectoryWithTime(directoryPattern, file, time)
-      actual must_== "something/{1970}/bar.gz"
+      actual must_== "something/1970/bar.gz"
     }
 
     "correctly decorate Time formats with multiple time patterns" in {
       val directoryPattern = Some("something/{YYYY}/{mm}dy={dd}")
       val actual = DynamicPath.decorateDirectoryWithTime(directoryPattern, file, time)
-      actual must_== "something/{1970}/{01}dy={01}/bar.gz"
+      actual must_== "something/1970/01dy=01/bar.gz"
     }
 
     "correctly decorate Time formats with extra trailing slash" in {
       val directoryPattern = Some("something/{YYYY}/{mm}dy={dd}/")
       val actual = DynamicPath.decorateDirectoryWithTime(directoryPattern, file, time)
-      actual must_== "something/{1970}/{01}dy={01}/bar.gz"
+      actual must_== "something/1970/01dy=01/bar.gz"
     }
 
     "correctly decorate Time formats with invalid time format" in {
       val directoryPattern = Some("something/{YYYY}/{mm}dy={dd}/{foo}")
       val actual = DynamicPath.decorateDirectoryWithTime(directoryPattern, file, time)
-      actual must_== "something/{1970}/{01}dy={01}/{foo}/bar.gz"
+      actual must_== "something/1970/01dy=01/foo/bar.gz"
     }
 
     "correctly handle no format" in {


### PR DESCRIPTION
The directory pattern currently allows DateTime pattern in the curly braces . to be resolved to actual date. This PR removes the braces used to indicate a pattern from the final directory.

Updated unit tests to reflect the correct behaviour.