### PR TITLE
chore: change Twitter maven repo to `https`

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,7 +16,7 @@ object Dependencies {
   val resolvers = Seq(
     Resolver.jcenterRepo,
     "Snowplow Analytics Maven releases repo" at "http://maven.snplow.com/releases/",
-    "Twitter maven repo"                     at "http://maven.twttr.com/"
+    "Twitter maven repo"                     at "https://maven.twttr.com/"
   )
 
   object V {


### PR DESCRIPTION
Twitter changed their Maven repo from `http` to `https` quite awhile back causing build to fail when finding for `hadoopLZO` package.

/cc @BenFradet 