### PR TITLE
Improve Kinesis / S3 configuration to run against mock services

### DIFF
--- a/examples/config.hocon.sample
+++ b/examples/config.hocon.sample
@@ -60,8 +60,9 @@ kinesis {
   appName = "{{appName}}"
 
   ## Optional endpoint url configuration to override aws kinesis endpoints,
-  ## this can be used to specify local endpoints when using localstack
+  ## this can be used to specify local endpoints when using localstack.
   # customEndpoint = {{kinesisEndpoint}}
+  # dynamoDBCustomEndpoint = {{kinesisEndpoint}}
 }
 
 streams {

--- a/examples/config.hocon.sample
+++ b/examples/config.hocon.sample
@@ -112,6 +112,12 @@ s3 {
   ## Optional endpoint url configuration to override aws s3 endpoints,
   ## this can be used to specify local endpoints when using localstack
   # customEndpoint = {{kinesisEndpoint}}
+
+  ## Enable S3 client Path-Style Access.
+  ## This can be used when using a local environment which does not support Virtual-Hosted based access such as
+  ## localstack.
+  ## Type: boolean
+  # pathStyleAccessEnabled = {{pathStyleAccessEnabled}}
 }
 
 # Optional section for tracking endpoints

--- a/src/main/scala/com.snowplowanalytics.s3/loader/KinesisSourceExecutor.scala
+++ b/src/main/scala/com.snowplowanalytics.s3/loader/KinesisSourceExecutor.scala
@@ -62,7 +62,9 @@ class KinesisSourceExecutor(
         kcc.APP_NAME,
         kcc.KINESIS_INPUT_STREAM,
         kcc.AWS_CREDENTIALS_PROVIDER,
-        kcc.WORKER_ID).withKinesisEndpoint(kcc.KINESIS_ENDPOINT)
+        kcc.WORKER_ID)
+          .withKinesisEndpoint(kcc.KINESIS_ENDPOINT)
+          .withDynamoDBEndpoint(kcc.DYNAMODB_ENDPOINT)
           .withFailoverTimeMillis(kcc.FAILOVER_TIME)
           .withMaxRecords(kcc.MAX_RECORDS)
           .withIdleTimeBetweenReadsInMillis(kcc.IDLE_TIME_BETWEEN_READS)

--- a/src/main/scala/com.snowplowanalytics.s3/loader/S3Emitter.scala
+++ b/src/main/scala/com.snowplowanalytics.s3/loader/S3Emitter.scala
@@ -77,6 +77,7 @@ class S3Emitter(
     .standard()
     .withCredentials(provider)
     .withEndpointConfiguration(new EndpointConfiguration(config.endpoint, config.region))
+    .withPathStyleAccessEnabled(config.pathStyleAccessEnabled)
     .build()
 
   /**

--- a/src/main/scala/com.snowplowanalytics.s3/loader/S3Loader.scala
+++ b/src/main/scala/com.snowplowanalytics.s3/loader/S3Loader.scala
@@ -112,6 +112,9 @@ object S3Loader {
     props.setProperty(KinesisConnectorConfiguration.PROP_APP_NAME, conf.kinesis.appName)
     props.setProperty(KinesisConnectorConfiguration.PROP_INITIAL_POSITION_IN_STREAM, conf.kinesis.initialPosition)
 
+    conf.kinesis.dynamoDBCustomEndpoint.foreach { endpoint =>
+      props.setProperty(KinesisConnectorConfiguration.PROP_DYNAMODB_ENDPOINT, endpoint)
+    }
     props.setProperty(KinesisConnectorConfiguration.PROP_S3_ENDPOINT, conf.s3.endpoint)
     props.setProperty(KinesisConnectorConfiguration.PROP_S3_BUCKET, conf.s3.bucket)
 

--- a/src/main/scala/com.snowplowanalytics.s3/loader/model.scala
+++ b/src/main/scala/com.snowplowanalytics.s3/loader/model.scala
@@ -39,7 +39,8 @@ package model {
     maxRecords: Long,
     region: String,
     appName: String,
-    customEndpoint: Option[String]
+    customEndpoint: Option[String],
+    dynamoDBCustomEndpoint: Option[String]
   ) {
     val timestampEither = initialTimestamp
       .toRight("An initial timestamp needs to be provided when choosing AT_TIMESTAMP")

--- a/src/main/scala/com.snowplowanalytics.s3/loader/model.scala
+++ b/src/main/scala/com.snowplowanalytics.s3/loader/model.scala
@@ -70,6 +70,7 @@ package model {
     maxTimeout: Long,
     outputDirectory: Option[String],
     customEndpoint: Option[String],
+    pathStyleAccessEnabled: Boolean = false,
     dateFormat: Option[String] = None,
     filenamePrefix: Option[String] = None
   ) {


### PR DESCRIPTION
This pull request aims at running the S3 loader locally against mocked services such as _localstack_ or _minio_.

To be able to read from Kinesis, the _KCL_ automatically creates a _DynamoDB_ table to keep the stream offset. When running locally, the _KCL DynamoDB_ endpoint should allow to be overridden  through the configuration to point to a local _DynamoDB_.

This is done by introducing an optional `dynamoDBCustomEndpoint` in the Kinesis configuration. This property is then propagated to _KCL_ configuration when it is defined.

The second part of that pull request introduces a configuration property for the S3 client: `pathStyleAccessEnabled`. That flag allows to enable the path-style access on the S3 client, instead of the default virtual-hosted access style, which is not necessarily supported by mocked services such as _localstack_.