### PR TITLE
Fix filename when no filenamePrefix is defined

### DIFF
--- a/src/main/scala/com.snowplowanalytics.s3/loader/KinesisS3Emitter.scala
+++ b/src/main/scala/com.snowplowanalytics.s3/loader/KinesisS3Emitter.scala
@@ -143,13 +143,20 @@ object KinesisS3Emitter {
     * Kinesis sequence range of records in the file.
     */
   def getBaseFilename(firstSeq: String, lastSeq: String, outputDirectory: Option[String], partition: Option[String], dateFormat: Option[String], filenamePrefix: Option[String], datetime: Option[LocalDateTime] = None): String = {
- val path = List(outputDirectory, partition, dateFormat, filenamePrefix)
+    val path = List(outputDirectory, partition, dateFormat)
       .flatMap(_.toList.filterNot(_.isEmpty))
       .mkString("/")
 
-    val filename = List(path, DateTimeFormatter.ISO_LOCAL_DATE.format(datetime.getOrElse(LocalDateTime.now)), firstSeq, lastSeq).filterNot(_.isEmpty).mkString("-")
+    val filename = List(
+        filenamePrefix.getOrElse(""),
+        DateTimeFormatter.ISO_LOCAL_DATE.format(datetime.getOrElse(LocalDateTime.now)),
+        firstSeq,
+        lastSeq
+      ).filterNot(_.isEmpty).mkString("-")
 
-    DynamicPath.normalize(filename)
+    val fullFilename = List(path, filename).filterNot(_.isEmpty).mkString("/")
+
+    DynamicPath.normalize(fullFilename)
   }
 
   /**

--- a/src/test/scala/com/snowplowanalytics/s3/loader/KinesisS3EmitterSpec.scala
+++ b/src/test/scala/com/snowplowanalytics/s3/loader/KinesisS3EmitterSpec.scala
@@ -40,6 +40,12 @@ class KinesisS3EmitterSpec extends Specification {
       actual must beEqualTo(s"1970-01-01-$firstSeq-$lastSeq")
     }
 
+    "format file name with optional components but no filenamePrefix" in {
+      val actual = KinesisS3Emitter.getBaseFilename(firstSeq, lastSeq, Some(outputDirectory), Some(partition), Some(dateFormat), None, Some(datetime))
+
+      actual must beEqualTo(s"$outputDirectory/$partition/$dateFormat/1970-01-01-$firstSeq-$lastSeq")
+    }
+
     "partition records correctly according to schema key" in {
       val dataType11 =
         """


### PR DESCRIPTION
When generating the output filename, if no filenamePrefix is defined the
file name should not include any prefix.
The filename generation was concatenating the prefix in the path
section, resulting in a filename starting with `-` when no
filenamePrefix is specified.

The fix consists of splitting the path and filename generation.
The filename generation is responsible of prepending the filenamePrefix
and then the path and filename are concatenated.