### PR TITLE
AWS OIDC authentication support for running s3-loader in EKS

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,7 @@ lazy val root = project.in(file("."))
   .settings(
     libraryDependencies ++= Seq(
       // Java
+      Dependencies.Libraries.sts,
       Dependencies.Libraries.kinesisClient,
       Dependencies.Libraries.kinesisConnector,
       Dependencies.Libraries.slf4j,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,7 +22,8 @@ object Dependencies {
   object V {
     // Java
     val slf4j            = "1.7.6"
-    val kinesisClient    = "1.7.5"
+    val kinesisClient    = "1.13.3"
+    val awsSts           = "1.11.797"
     val kinesisConnector = "1.3.0"
     val hadoop           = "2.7.3"
     val elephantbird     = "4.15"
@@ -47,6 +48,7 @@ object Dependencies {
   object Libraries {
     // Java
     val slf4j            = "org.slf4j"                 %  "slf4j-simple"              % V.slf4j
+    val sts              = "com.amazonaws"             %  "aws-java-sdk-sts"          % V.awsSts
     val kinesisClient    = ("com.amazonaws"            %  "amazon-kinesis-client"     % V.kinesisClient)
       .exclude("com.fasterxml.jackson.dataformat", "jackson-dataformat-cbor")
     val kinesisConnector = ("com.amazonaws"            %  "amazon-kinesis-connectors" % V.kinesisConnector)

--- a/src/main/scala/com.snowplowanalytics.s3/loader/CredentialsLookup.scala
+++ b/src/main/scala/com.snowplowanalytics.s3/loader/CredentialsLookup.scala
@@ -49,6 +49,10 @@ object CredentialsLookup {
       new EnvironmentVariableCredentialsProvider()
     } else if (isEnv(a) || isEnv(s)) {
       throw new RuntimeException("access-key and secret-key must both be set to 'env', or neither")
+    } else if (isOIDC(a) && isOIDC(s)) {
+      new WebIdentityTokenCredentialsProvider()
+    } else if (isOIDC(a) || isOIDC(s)) {
+      throw new RuntimeException("access-key and secret-key must both be set to 'env', or neither")
     } else {
       new BasicAWSCredentialsProvider(
         new BasicAWSCredentials(a, s)
@@ -82,6 +86,15 @@ object CredentialsLookup {
    * @return true if key is iam, false otherwise
    */
   private def isEnv(key: String): Boolean = (key == "env")
+
+  /**
+   * Is the access/secret key set to the special value "oidc" i.e. get
+   * the credentials from WebToken provider 
+   *
+   * @param key The key to check
+   * @return true if key is oidc, false otherwise
+   */
+  private def isOIDC(key: String): Boolean = (key == "oidc")
 
   // Wrap BasicAWSCredential objects.
   class BasicAWSCredentialsProvider(basic: BasicAWSCredentials) extends


### PR DESCRIPTION
This PR adds support for using the WebTokenAuOIDC based authentication. This is used with running the container in an EKS cluster with IAM roles associated to K8S Service accounts (see https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)

To enable the accessKey and secretKey should be set to `oidc`
```
    aws {
      accessKey = "oidc"
      secretKey = "oidc"
    }
```

