### PR TITLE
Fix Snyk step to track the two different flavours

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
         if: ${{ !contains(github.ref_name, 'rc') && fromJSON(matrix.runSnyk) }}
         with:
           image: "snowplow/snowplow-s3-loader:${{ github.ref_name }}${{ matrix.dockerTagSuffix }}"
-          args: "--app-vulns --org=99605b41-ca0f-42c9-a9ff-45c201a10a26"
+          args: "--app-vulns --org=99605b41-ca0f-42c9-a9ff-45c201a10a26 --project-name=snowplow-s3-loader-${{ matrix.sbtProject }}"
           command: monitor
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: 11
           distribution: adopt
+
+      - name: Install sbt
+        uses: sbt/setup-sbt@v1
 
       - name: Install LZO
         run: sudo apt-get install -y lzop liblzo2-dev
@@ -55,13 +58,17 @@ jobs:
             dockerTagSuffix: "-distroless"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: 11
           distribution: adopt
+
+      - name: Install sbt
+        uses: sbt/setup-sbt@v1
+
       - name: Login to Docker Hub
         run: docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
         env:
@@ -110,13 +117,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: 11
           distribution: adopt
+
+      - name: Install sbt
+        uses: sbt/setup-sbt@v1
 
       - name: Install LZO
         run: sudo apt-get install -y lzop liblzo2-dev


### PR DESCRIPTION
The S3 Loader has two flavours: lzo and distroless.
The current GitHub Actions workflow (ci.yml) mistakenly pushes both images to the same Snyk project.
This PR fixes that by explicitly naming the projects, so we end up with snowplow-s3-loader-lzo and snowplow-s3-loader-distroless.

Note: I’ve opened this PR against the arm-docker-image branch because it already includes several improvements that we probably want to merge into develop.